### PR TITLE
Improve example notebook

### DIFF
--- a/etc/Example.ipynb
+++ b/etc/Example.ipynb
@@ -4,7 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Decoding bunch pattern data"
+    "## Reading EuXFEL bunch pattern data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each pulse train at EuXFEL consists of up to 2700 X-ray pulses.\n",
+    "The 'bunch pattern table' stores information about the production of pulses,\n",
+    "each of which corresponds to one bunch of electrons in the accelerator.\n",
+    "\n",
+    "The information for each pulse is packed into a 32-bit integer.\n",
+    "Every table has 2700 entries - skipped pulses are represented as 0.\n",
+    "\n",
+    "The code below loads the bunch tables for all trains in the specified run."
    ]
   },
   {
@@ -13,62 +27,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from karabo_data import RunDirectory\n",
-    "import bunch_pattern"
+    "from extra_data import open_run\n",
+    "import euxfel_bunch_pattern"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "run = RunDirectory('/gpfs/exfel/exp/SCS/201802/p002197/raw/r0462/')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The bunch pattern is saved by the time server as an array of 32-bit integers, one for each possible pulse."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bunch_pattern_tables = run.get_array('SCS_RR_UTC/TSYS/TIMESERVER', 'bunchPatternTable.value', extra_dims=['pulse_slot'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "<xarray.DataArray (trainId: 5, pulse_slot: 2700)>\n",
-       "array([[2146089,   32768,   33024, ...,       0,       0,       0],\n",
-       "       [2146089,   32768,   33024, ...,       0,       0,       0],\n",
-       "       [2146089,   32768,   33024, ...,       0,       0,       0],\n",
-       "       [2146089,   32768,   33024, ...,       0,       0,       0],\n",
-       "       [2146089,   32768,   33024, ...,       0,       0,       0]],\n",
+       "array([[2141993,       0, 2129961, ...,       0,       0,       0],\n",
+       "       [2139945,       0, 2129961, ...,       0,       0,       0],\n",
+       "       [2141993,       0, 2129961, ...,       0,       0,       0],\n",
+       "       [2139945,       0, 2129961, ...,       0,       0,       0],\n",
+       "       [2141993,       0, 2129961, ...,       0,       0,       0]],\n",
        "      dtype=uint32)\n",
        "Coordinates:\n",
-       "  * trainId  (trainId) uint64 45297262 45297263 45297264 45297265 45297266\n",
+       "  * trainId  (trainId) uint64 517755296 517755297 517755298 517755299 517755300\n",
        "Dimensions without coordinates: pulse_slot"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "bunch_pattern_tables[:5]"
+    "# Proposal 700000 contains sample data - this run is originally from prop. 2212 at SCS.\n",
+    "run = open_run(proposal=700000, run=26)\n",
+    "\n",
+    "bunch_pattern_tables = run.get_array(\n",
+    "    'SCS_RR_UTC/TSYS/TIMESERVER', 'bunchPatternTable.value', extra_dims=['pulse_slot']\n",
+    ")\n",
+    "\n",
+    "bunch_pattern_tables[:5]   # Examine the first few tables"
    ]
   },
   {
@@ -89,31 +85,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train 45297262: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297263: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297264: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297265: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297266: 0 pulses to SASE1, 30 to SASE3\n",
-      "Train 45297267: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297268: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297269: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297270: 128 pulses to SASE1, 0 to SASE3\n",
-      "Train 45297271: 0 pulses to SASE1, 30 to SASE3\n"
+      "Train 517755296: 10 pulses to SASE1, 50 to SASE3\n",
+      "Train 517755297: 10 pulses to SASE1, 50 to SASE3\n",
+      "Train 517755298: 10 pulses to SASE1, 50 to SASE3\n",
+      "Train 517755299: 10 pulses to SASE1, 50 to SASE3\n",
+      "Train 517755300: 10 pulses to SASE1, 50 to SASE3\n"
      ]
     }
    ],
    "source": [
-    "for table in bunch_pattern_tables[:10]:\n",
+    "for table in bunch_pattern_tables[:5]:\n",
     "    tid = table.trainId.item()\n",
-    "    sase1_pulses = bunch_pattern.indices_at_sase(table.data, sase=1)\n",
-    "    sase3_pulses = bunch_pattern.indices_at_sase(table.data, sase=3)\n",
+    "    sase1_pulses = euxfel_bunch_pattern.indices_at_sase(table.data, sase=1)\n",
+    "    sase3_pulses = euxfel_bunch_pattern.indices_at_sase(table.data, sase=3)\n",
     "    print(f\"Train {tid}: {len(sase1_pulses)} pulses to SASE1, {len(sase3_pulses)} to SASE3\")"
    ]
   },
@@ -121,29 +112,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The *pulsePatternDecoder* Karabo device also produces this information:"
+    "The `BUNCH_DECODER` source (Karabo device `pulsePatternDecoder`) records this information in a more convenient format:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<xarray.DataArray (trainId: 10)>\n",
-      "array([ 0,  0,  0,  0, 30,  0,  0,  0,  0, 30], dtype=int32)\n",
-      "Coordinates:\n",
-      "  * trainId  (trainId) uint64 45297262 45297263 45297264 45297265 45297266 ...\n"
-     ]
+     "data": {
+      "text/plain": [
+       "<xarray.DataArray (trainId: 10)>\n",
+       "array([50, 50, 50, 50, 50, 50, 50, 50, 50, 50], dtype=int32)\n",
+       "Coordinates:\n",
+       "  * trainId  (trainId) uint64 517755296 517755297 ... 517755304 517755305"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(run.get_array('SCS_RR_UTC/MDL/BUNCH_DECODER', 'sase3.nPulses.value')[:10])"
+    "run.get_array('SCS_RR_UTC/MDL/BUNCH_DECODER', 'sase3.nPulses.value')[:10]"
    ]
   },
   {
@@ -151,79 +145,89 @@
    "metadata": {},
    "source": [
     "We can also check this against an *X-ray Gas Monitor* (XGM) in SASE3.\n",
-    "In trains where bunches are sent to SASE3, the XGM registers pulses with intensity > 3000,\n",
-    "compared to < 1000 for the other trains.\n",
     "\n",
-    "This XGM didn't record data for all trains, so we need to align the data.\n",
+    "In the numbers below, an XGM intensity of ~6000 indicates a pulse in SASE3.\n",
+    "When there's no pulse, the intensity value is much smaller.\n",
+    "\n",
+    "The XGM may not record data for all trains, so we need to align the data.\n",
     "In the output below, missing data from the XGM shows up as `nan` (Not A Number).\n",
     "If we aligned with `join='inner'`, these rows would be dropped instead."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray\n",
+    "np.set_printoptions(precision=1, suppress=True)  # Simplify number formatting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train 45297262:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [437.2743  206.8512  283.20245 418.04456 349.41214]...\n",
+      "Train 517755296:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   4.2 7244.2  -13.6   -1.2 7265.8  -19.6    2.7 6235.8   -7.8    5.8]...\n",
       "\n",
-      "Train 45297263:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [nan nan nan nan nan]...\n",
+      "Train 517755297:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [  -1.5 6630.   -23.1   -1.3 6854.6  -19.3    9.  6851.4  -22.3  -10. ]...\n",
       "\n",
-      "Train 45297264:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [121.54636  72.26654 175.06305  99.43744  72.64107]...\n",
+      "Train 517755298:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [  10.  6929.4  -15.9    7.4 6962.8  -12.3    2.3 6698.6  -16.8    3.5]...\n",
       "\n",
-      "Train 45297265:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [115.02722   60.6854   110.661606 102.08841  128.99011 ]...\n",
+      "Train 517755299:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   0.2 7186.3  -21.1    6.2 7004.5    1.2    7.4 7183.2   -8.3    4.9]...\n",
       "\n",
-      "Train 45297266:\n",
-      "  Bunches to SASE3: [240 256 272 288 304 320 336 352 368 384]...\n",
-      "   XGM intensities: [3.4325640e+03 2.0774655e+00 6.4372176e-01 3.7218819e+00 3.2275093e+03]...\n",
+      "Train 517755300:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   5.3 7398.2   -2.9   10.6 6416.2   -9.5    6.  6963.9  -23.2    2.2]...\n",
       "\n",
-      "Train 45297267:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [124.928825 174.05649  171.65717  113.17213  132.65349 ]...\n",
+      "Train 517755301:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   2.8 7037.7  -18.7   11.8 7043.2   -7.7    8.2 6914.1   -1.5    9.1]...\n",
       "\n",
-      "Train 45297268:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [nan nan nan nan nan]...\n",
+      "Train 517755302:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   4.9 6787.3  -20.4    2.1 7047.   -22.2    8.4 6594.9  -11.6    7. ]...\n",
       "\n",
-      "Train 45297269:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [123.30196   90.413635  91.29729   89.01501   65.168045]...\n",
+      "Train 517755303:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   2.8 6830.2  -11.5   13.  7344.7  -12.4    8.4 6751.5  -19.3    2.5]...\n",
       "\n",
-      "Train 45297270:\n",
-      "  Bunches to SASE3: []...\n",
-      "   XGM intensities: [185.49133   78.77983   93.73758   35.030167  95.65704 ]...\n",
+      "Train 517755304:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   7.5 6867.3   -7.3    5.2 7216.8  -26.1    1.1 7217.8  -18.4    2.5]...\n",
       "\n",
-      "Train 45297271:\n",
-      "  Bunches to SASE3: [240 256 272 288 304 320 336 352 368 384]...\n",
-      "   XGM intensities: [ 3.4964856e+03 -5.3838539e-01  2.9143038e+00  3.4526893e-01\n",
-      "  3.2865796e+03]...\n",
+      "Train 517755305:\n",
+      "  Bunches to SASE3: [882 890 898 906 914 922 930 938 946 954]...\n",
+      "   XGM intensities: [   5.  6865.   -10.8    8.3 7031.5   -9.8    6.1 6785.6   -7.9    5.3]...\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "import xarray\n",
     "sa3_xgm_intensity = run.get_array('SA3_XTD10_XGM/XGM/DOOCS:output', 'data.intensityTD')\n",
-    "bunch_pattern_tables, sa3_xgm_intensity = xarray.align(bunch_pattern_tables, sa3_xgm_intensity, join='outer')\n",
+    "\n",
+    "bunch_pattern_tables, sa3_xgm_intensity = \\\n",
+    "    xarray.align(bunch_pattern_tables, sa3_xgm_intensity, join='outer')\n",
     "\n",
     "for bunch_table, intensities in zip(bunch_pattern_tables[:10], sa3_xgm_intensity):\n",
     "    print(f\"Train {bunch_table.trainId.item()}:\")\n",
-    "    sa3_pulses = bunch_pattern.indices_at_sase(bunch_table.values, sase=3)\n",
+    "    sa3_pulses = euxfel_bunch_pattern.indices_at_sase(bunch_table.values, sase=3)\n",
     "    print(f\"  Bunches to SASE3: {sa3_pulses[:10]}...\")\n",
-    "    print(f\"   XGM intensities: {intensities[:5].values}...\")\n",
+    "    print(f\"   XGM intensities: {intensities[:10].values}...\")\n",
     "    print()"
    ]
   },
@@ -243,40 +247,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  ,\n",
-       "       0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  ,\n",
-       "       0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36,\n",
-       "       0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  ,\n",
-       "       0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  ,\n",
-       "       0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  ,\n",
-       "       0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36,\n",
-       "       0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  ,\n",
-       "       0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  ,\n",
-       "       0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  ,\n",
-       "       0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36,\n",
-       "       0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  ,\n",
-       "       0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  ,\n",
-       "       0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  ,\n",
-       "       0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36,\n",
-       "       0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  ,\n",
-       "       0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  ,\n",
-       "       0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  , 0.  , 0.  , 0.36, 0.  ,\n",
-       "       0.  , 0.  ])"
+       "array([0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. ,\n",
+       "       0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4, 0. , 0.4,\n",
+       "       0. , 0.4, 0. , 0.4, 0. ])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "bunch_pattern.get_charge(bunch_pattern_tables[0, :200])"
+    "euxfel_bunch_pattern.get_charge(bunch_pattern_tables[0, :200])"
    ]
   }
  ],
@@ -296,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Use the new module name `euxfel_bunch_pattern`
- Use `extra_data`
- Use data from an XMPL run, so that anyone can run the notebook
- More explanation

The XMPL data is a bit confusing, though - the XGM seems to show one pulse in 3 going to SASE3, while the bunch pattern data indicates one pulse in 8. 3 is not a factor of 8. So either the XGM sampling rate was not set to a fraction of the pulse rate, or something is going wrong with decoding the information, or something else is going on that I don't understand. Any ideas?

I also added an `at_sase` function which can return a boolean array for which pulses were sent to a given SASE - this can easily be used with several trains at once.